### PR TITLE
Bump commons-beanutils in /jeecg-common/jeecg-common-core

### DIFF
--- a/jeecg-common/jeecg-common-core/pom.xml
+++ b/jeecg-common/jeecg-common-core/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>commons-beanutils</groupId>
 			<artifactId>commons-beanutils</artifactId>
-			<version>1.8.0</version>
+			<version>1.9.4</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Bumps commons-beanutils from 1.8.0 to 1.9.4.

Signed-off-by: dependabot[bot] <support@github.com>